### PR TITLE
Ensure ICTV IDs receive hyperlinks in error report

### DIFF
--- a/vmr_update_sql.py
+++ b/vmr_update_sql.py
@@ -293,9 +293,9 @@ class ErrorCollector:
                 if ictv_col_idx is not None:
                     cell = worksheet.cell(row=excel_row, column=ictv_col_idx)
                     value = cell.value
-                    if isinstance(value, str):
-                        stripped = value.strip()
-                        if re.fullmatch(r"VMR\d+", stripped):
+                    if value is not None:
+                        stripped = str(value).strip()
+                        if stripped:
                             cell.hyperlink = f"https://ictv.global/id/{stripped}"
                             cell.style = "Hyperlink"
                 if accession_col_idx is not None:


### PR DESCRIPTION
## Summary
- ensure ICTV_ID cells in the generated errors.xlsx always get a hyperlink to the ICTV site, even when the value contains whitespace or is not matched by the previous regex

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda01f085483259914238742281620